### PR TITLE
Fix issues with JSON quoting `%text%` content

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment:2.0.0'
     implementation 'androidx.navigation:navigation-ui:2.0.0'
     implementation "androidx.work:work-runtime:$work_version"
+    implementation 'org.apache.commons:commons-text:1.9'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.7.0'

--- a/app/src/main/java/tech/bogomolov/incomingsmsgateway/SmsReceiver.java
+++ b/app/src/main/java/tech/bogomolov/incomingsmsgateway/SmsReceiver.java
@@ -17,6 +17,9 @@ import androidx.work.WorkRequest;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+
+import org.apache.commons.text.StringEscapeUtils;
 
 public class SmsReceiver extends BroadcastReceiver {
 
@@ -62,12 +65,11 @@ public class SmsReceiver extends BroadcastReceiver {
 
         String messageContent = matchedConfig.getTemplate()
                 .replaceAll("%from%", sender)
-                .replaceAll("%text%",
-                        content.toString().replaceAll("\"", "\\\\\""))
                 .replaceAll("%sentStamp%", String.valueOf(messages[0].getTimestampMillis()))
                 .replaceAll("%receivedStamp%", String.valueOf(System.currentTimeMillis()))
-                .replaceAll("%sim%", this.detectSim(bundle));
-
+                .replaceAll("%sim%", this.detectSim(bundle))
+                .replaceAll("%text%",
+                        Matcher.quoteReplacement(StringEscapeUtils.escapeJson(content.toString())));
         this.callWebHook(
                 matchedConfig.getUrl(),
                 messageContent,


### PR DESCRIPTION
I wasn't having luck with the application properly JSON-quoting text message content - this PR fixes that. Also, it makes `%text%` the final replacement to be done, as the text message could contain references to other attributes that should not be replaced with their values.