### PR TITLE
Implement fixed Content-Length instead of Transfer-Encoding Chunked

### DIFF
--- a/app/src/main/java/tech/bogomolov/incomingsmsgateway/WebHookWorkRequest.java
+++ b/app/src/main/java/tech/bogomolov/incomingsmsgateway/WebHookWorkRequest.java
@@ -95,7 +95,7 @@ public class WebHookWorkRequest extends Worker {
             }
 
             urlConnection.setDoOutput(true);
-            urlConnection.setChunkedStreamingMode(0);
+            urlConnection.setFixedLengthStreamingMode(text.length());
 
             urlConnection.setRequestProperty("Content-Type", "application/json; charset=utf-8");
 


### PR DESCRIPTION
Fixes #49

Tested on Android 10, release apk.

Fixes compatibility with Microsoft Teams Incoming Webhooks.