### PR TITLE
Feature: Add Regex to message template to select a part of a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Sample payload:
      "text": "%text%",
      "sentStamp": "%sentStamp%",
      "receivedStamp": "%receivedStamp%",
-     "sim": "%sim%"
+     "sim": "%sim%",
+     "customText": "%Regex=[1-0]%"
 }
 ```
 
@@ -65,6 +66,7 @@ Available placeholders:
 %sentStamp%
 %receivedStamp%
 %sim%
+%Regex=%
 
 ### Request example
 Use this curl sample request to prepare your backend code

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 33
         versionCode 12
-        versionName "2.3.0"
+        versionName "2.4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="label_chunked_mode">Chunked Mode (vs Fixed Length)</string>
     <string name="hint_sender">number or text</string>
     <string name="sender_recommendation">Use * symbol to catch any SMS</string>
-    <string name="json_template_recommendation">Available placeholders %text%, %from%, %sentStamp%, %receivedStamp%, %sim%</string>
+    <string name="json_template_recommendation">Available placeholders %text%, %from%, %sentStamp%, %receivedStamp%, %sim%, %Regex=%</string>
     <string name="error_empty_sender">Empty sender</string>
     <string name="error_empty_url">Empty URL</string>
     <string name="error_wrong_url">Wrong URL</string>


### PR DESCRIPTION
This PR introduces regex pattern matching capabilities to the SMS forwarding functionality, allowing users to extract specific content from SMS messages before sending to the server.
This enhancement enables send only relevant parts of SMS messages (e.g., OTP codes, transaction amounts).
Example Usage:
%Regex=code:\s*(\d+)%