### PR TITLE
Add notification listener fallback for SMS forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ issue #46).
 **Workaround:** turn off RCS in Google Messages (Settings → RCS chats → *Turn off
 RCS chats*). Messages will then arrive as normal SMS and be forwarded correctly.
 
+### Notification forwarding recovery
+
+The app also has a notification-listener fallback for phones that do not
+deliver some verification SMS messages through `SMS_RECEIVED`. Open the action
+bar menu and tap **Notification access**, enable this app in Android system
+settings, then edit the forwarding rule's **Notification text filter**. The
+fallback reads the notification title and visible text. If the field is empty,
+every readable notification body is forwarded; if you enter a regex, only
+matching notification text is forwarded. The SMS text filter is used only for
+SMS broadcasts; the notification filter is used only for notifications. Both
+paths share the sender filter, template, HMAC signature and retry queue.
+
+Some Android vendors disconnect notification listeners after clearing an app
+from the task list. When this app is opened again, it now checks that
+notification access is still enabled and asks Android to rebind the listener
+immediately, then retries once after a short delay. The Syslog shows
+`requested notification listener rebind` followed by `notification listener
+connected` when recovery succeeds; toggling notification access should no
+longer be necessary.
+
+The notification title is used as `%from%` and the visible notification body is
+used as `%text%`; SIM-specific rules are not applied to notification messages.
+The app never logs the message body. Android/OEM settings can redact sensitive
+notification content or suppress notifications entirely; in that case no
+third-party notification listener can recover the code and the SMS fallback
+cannot help.
+
 ### Optional Features
 
 #### Match the sender with a regex

--- a/app/src/androidTest/java/tech/bogomolov/incomingsmsgateway/ForwardingConfigTest.java
+++ b/app/src/androidTest/java/tech/bogomolov/incomingsmsgateway/ForwardingConfigTest.java
@@ -41,6 +41,7 @@ public class ForwardingConfigTest {
     public void testSaveAndGetAllRoundTrip() {
         ForwardingConfig config = new ForwardingConfig(context);
         config.setSender("+16505551111");
+        config.setNotificationFilter("(?i)呱呱研选.*验证码");
         config.setUrl("https://example.com/hook");
         config.setSimSlot(2);
         config.setTemplate("{\"text\":\"%text%\"}");
@@ -58,6 +59,7 @@ public class ForwardingConfigTest {
 
         ForwardingConfig loaded = all.get(0);
         assertEquals("+16505551111", loaded.getSender());
+        assertEquals("(?i)呱呱研选.*验证码", loaded.getNotificationFilter());
         assertEquals("https://example.com/hook", loaded.getUrl());
         assertEquals(2, loaded.getSimSlot());
         assertEquals("{\"text\":\"%text%\"}", loaded.getTemplate());
@@ -192,6 +194,7 @@ public class ForwardingConfigTest {
         // must survive an export → wipe → import cycle byte-for-byte, including key.
         ForwardingConfig config = new ForwardingConfig(context);
         config.setSender("+16505551111");
+        config.setNotificationFilter("(?i)验证码");
         config.setUrl("https://example.com/hook");
         config.setSimSlot(2);
         config.setTemplate("{\"text\":\"%text%\"}");
@@ -219,6 +222,7 @@ public class ForwardingConfigTest {
         ForwardingConfig loaded = ForwardingConfig.getAll(context).get(0);
         assertEquals(originalKey, loaded.getKey());
         assertEquals("+16505551111", loaded.getSender());
+        assertEquals("(?i)验证码", loaded.getNotificationFilter());
         assertEquals("https://example.com/hook", loaded.getUrl());
         assertEquals(2, loaded.getSimSlot());
         assertEquals("{\"text\":\"%text%\"}", loaded.getTemplate());

--- a/app/src/androidTest/java/tech/bogomolov/incomingsmsgateway/SmsReceiverTest.java
+++ b/app/src/androidTest/java/tech/bogomolov/incomingsmsgateway/SmsReceiverTest.java
@@ -57,6 +57,22 @@ public class SmsReceiverTest {
     }
 
     @Test
+    public void testSmsPassedToWebhookWithExplicitPduFormat() {
+        this.setPhoneConfig(appContext, appContext.getString(R.string.asterisk));
+        SmsBroadcastReceiver receiver = this.getSmsReceiver();
+        receiver.onReceive(appContext, this.getIntentWithFormat("3gpp"));
+
+        Mockito.verify(receiver, Mockito.times(1))
+                .callWebHook(
+                        Mockito.any(ForwardingConfig.class),
+                        Mockito.anyString(),
+                        Mockito.anyString(),
+                        Mockito.anyString(),
+                        Mockito.anyLong()
+                );
+    }
+
+    @Test
     public void testSmsPassedToWebhookByNumber() {
         this.setPhoneConfig(appContext, this.getSender());
         SmsBroadcastReceiver receiver = this.getSmsReceiver();
@@ -204,6 +220,12 @@ public class SmsReceiverTest {
     private Intent getIntentMultiPdus() {
         Intent intent = new Intent(Telephony.Sms.Intents.SMS_RECEIVED_ACTION);
         intent.putExtra("pdus", this.getTestMultiplePdu());
+        return intent;
+    }
+
+    private Intent getIntentWithFormat(String format) {
+        Intent intent = this.getIntent();
+        intent.putExtra("format", format);
         return intent;
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,17 @@
             android:enabled="true"
             android:exported="true" />
 
+        <service
+            android:name=".NotificationListener"
+            android:enabled="true"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
         <!--
             SMS delivery is driven by this manifest-declared receiver, not by a
             receiver registered at runtime inside SmsReceiverService. SMS_RECEIVED

--- a/app/src/main/java/tech/bogomolov/incomingsmsgateway/ForwardingConfig.java
+++ b/app/src/main/java/tech/bogomolov/incomingsmsgateway/ForwardingConfig.java
@@ -26,6 +26,7 @@ public class ForwardingConfig {
     private static final String KEY_SENDER = "sender";
     private static final String KEY_IS_SENDER_REGEX = "is_sender_regex";
     private static final String KEY_SMS_FILTER = "sms_filter";
+    private static final String KEY_NOTIFICATION_FILTER = "notification_filter";
     private static final String KEY_URL = "url";
     private static final String KEY_SIM_SLOT = "sim_slot";
     private static final String KEY_TEMPLATE = "template";
@@ -43,6 +44,7 @@ public class ForwardingConfig {
     private String sender;
     private boolean isSenderRegex = false; // when true, sender is matched as a regex
     private String smsFilter = ""; // empty means forward every message
+    private String notificationFilter = ""; // empty means forward every readable notification
     private String url;
     private int simSlot = 0; // 0 means any
     private String template;
@@ -90,6 +92,14 @@ public class ForwardingConfig {
 
     public void setSmsFilter(String smsFilter) {
         this.smsFilter = smsFilter == null ? "" : smsFilter;
+    }
+
+    public String getNotificationFilter() {
+        return this.notificationFilter;
+    }
+
+    public void setNotificationFilter(String notificationFilter) {
+        this.notificationFilter = notificationFilter == null ? "" : notificationFilter;
     }
 
     public String getUrl() {
@@ -213,6 +223,7 @@ public class ForwardingConfig {
         json.put(KEY_SENDER, this.sender);
         json.put(KEY_IS_SENDER_REGEX, this.isSenderRegex);
         json.put(KEY_SMS_FILTER, this.smsFilter);
+        json.put(KEY_NOTIFICATION_FILTER, this.notificationFilter);
         json.put(KEY_URL, this.url);
         json.put(KEY_SIM_SLOT, this.simSlot);
         json.put(KEY_TEMPLATE, this.template);
@@ -282,6 +293,9 @@ public class ForwardingConfig {
 
                 if (json.has(KEY_SMS_FILTER)) {
                     config.setSmsFilter(json.getString(KEY_SMS_FILTER));
+                }
+                if (json.has(KEY_NOTIFICATION_FILTER)) {
+                    config.setNotificationFilter(json.getString(KEY_NOTIFICATION_FILTER));
                 }
 
                 if (json.has(KEY_IS_SMS_ENABLED)) {

--- a/app/src/main/java/tech/bogomolov/incomingsmsgateway/ForwardingConfigDialog.java
+++ b/app/src/main/java/tech/bogomolov/incomingsmsgateway/ForwardingConfigDialog.java
@@ -120,6 +120,9 @@ public class ForwardingConfigDialog {
         final EditText smsFilterInput = view.findViewById(R.id.input_sms_filter);
         smsFilterInput.setText(config.getSmsFilter());
 
+        final EditText notificationFilterInput = view.findViewById(R.id.input_notification_filter);
+        notificationFilterInput.setText(config.getNotificationFilter());
+
         final EditText urlInput = view.findViewById(R.id.input_url);
         urlInput.setText(config.getUrl());
 
@@ -203,6 +206,9 @@ public class ForwardingConfigDialog {
         final EditText smsFilterInput = view.findViewById(R.id.input_sms_filter);
         String smsFilter = smsFilterInput.getText().toString();
 
+        final EditText notificationFilterInput = view.findViewById(R.id.input_notification_filter);
+        String notificationFilter = notificationFilterInput.getText().toString();
+
         final EditText urlInput = view.findViewById(R.id.input_url);
         String url = urlInput.getText().toString();
         if (TextUtils.isEmpty(url)) {
@@ -272,6 +278,7 @@ public class ForwardingConfigDialog {
         config.setSender(sender);
         config.setIsSenderRegex(isSenderRegex);
         config.setSmsFilter(smsFilter);
+        config.setNotificationFilter(notificationFilter);
         config.setUrl(url);
         config.setTemplate(template);
         config.setHeaders(headers);

--- a/app/src/main/java/tech/bogomolov/incomingsmsgateway/MainActivity.java
+++ b/app/src/main/java/tech/bogomolov/incomingsmsgateway/MainActivity.java
@@ -2,12 +2,15 @@ package tech.bogomolov.incomingsmsgateway;
 
 import android.Manifest;
 import android.app.ActivityManager;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.DataSetObserver;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -35,6 +38,10 @@ public class MainActivity extends AppCompatActivity {
 
     private Context context;
     private ListAdapter listAdapter;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final Runnable notificationRebindRetry =
+            () -> NotificationListener.requestRebindIfEnabled(
+                    getApplicationContext(), "activity resume retry");
 
     private static final int PERMISSION_CODE = 0;
 
@@ -95,6 +102,12 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        // OEM task cleaners can kill a NotificationListenerService without
+        // delivering onListenerDisconnected. Opening the app must recover it
+        // without requiring the user to toggle Notification access manually.
+        NotificationListener.requestRebindIfEnabled(getApplicationContext(), "activity resume");
+        mainHandler.removeCallbacks(notificationRebindRetry);
+        mainHandler.postDelayed(notificationRebindRetry, 1000L);
         // Failures accrue in the background, so refresh the retry counter each
         // time the activity comes forward.
         invalidateOptionsMenu();
@@ -104,6 +117,12 @@ public class MainActivity extends AppCompatActivity {
             listAdapter.clear();
             listAdapter.addAll(ForwardingConfig.getAll(this));
         }
+    }
+
+    @Override
+    protected void onPause() {
+        mainHandler.removeCallbacks(notificationRebindRetry);
+        super.onPause();
     }
 
     @Override
@@ -132,6 +151,17 @@ public class MainActivity extends AppCompatActivity {
             return true;
         }
 
+        if (id == R.id.action_bar_notification_access) {
+            try {
+                // Use the action string instead of the API-21 constant so the
+                // APK remains safe on older devices (minSdk is 14).
+                startActivity(new Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS"));
+            } catch (ActivityNotFoundException e) {
+                Toast.makeText(this, R.string.notification_access_unavailable, Toast.LENGTH_LONG).show();
+            }
+            return true;
+        }
+
         if (id == R.id.action_bar_retry_failed) {
             int count = FailedMessage.getCount(this);
             FailedMessage.retryAll(this);
@@ -141,14 +171,20 @@ public class MainActivity extends AppCompatActivity {
         }
 
         if (id == R.id.action_bar_syslogs) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(context);
+            AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
             View view = getLayoutInflater().inflate(R.layout.syslogs, null);
 
             String logs = "";
             try {
+                // Runtime.exec does not interpret shell pipes. Use logcat's own
+                // tag filters so receiver and webhook diagnostics are visible.
                 String[] command = new String[]{
-                        "logcat", "-d", "*:E", "-m", "1000",
-                        "|", "grep", "tech.bogomolov.incomingsmsgateway"};
+                        "logcat", "-d", "-v", "time", "-s",
+                        "SmsBroadcastReceiver:I",
+                        "NotificationListener:I",
+                        "SmsGateway:I",
+                        "RequestWorker:I",
+                        "AndroidRuntime:E"};
                 Process process = Runtime.getRuntime().exec(command);
 
                 BufferedReader bufferedReader = new BufferedReader(

--- a/app/src/main/java/tech/bogomolov/incomingsmsgateway/NotificationListener.java
+++ b/app/src/main/java/tech/bogomolov/incomingsmsgateway/NotificationListener.java
@@ -1,0 +1,200 @@
+package tech.bogomolov.incomingsmsgateway;
+
+import android.app.Notification;
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.service.notification.NotificationListenerService;
+import android.service.notification.StatusBarNotification;
+import android.util.Log;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Receives readable notifications when an OEM does not deliver SMS_RECEIVED.
+ * The user must explicitly enable notification access in Android settings; no
+ * runtime permission can grant this access silently.
+ */
+public class NotificationListener extends NotificationListenerService {
+
+    private static final String TAG = "NotificationListener";
+    private static final String ENABLED_NOTIFICATION_LISTENERS = "enabled_notification_listeners";
+
+    private static final String[] BODY_KEYS = new String[]{
+            Notification.EXTRA_TEXT,
+            Notification.EXTRA_BIG_TEXT,
+            Notification.EXTRA_SUB_TEXT,
+            Notification.EXTRA_INFO_TEXT,
+            Notification.EXTRA_SUMMARY_TEXT
+    };
+
+    private static final String[] REDACTED_TEXTS = new String[]{
+            "Sensitive notification content hidden",
+            "已隐藏敏感通知内容",
+            "系統已隱藏含有私密資訊的通知內容",
+            "敏感通知内容已隐藏"
+    };
+
+    @Override
+    public void onListenerConnected() {
+        super.onListenerConnected();
+        Log.i(TAG, "notification listener connected");
+    }
+
+    @Override
+    public void onNotificationPosted(StatusBarNotification sbn) {
+        super.onNotificationPosted(sbn);
+        if (sbn == null || BuildConfig.APPLICATION_ID.equals(sbn.getPackageName())) {
+            return;
+        }
+
+        Notification notification = sbn.getNotification();
+        if (notification == null) {
+            return;
+        }
+
+        int flags = notification.flags;
+        if ((flags & Notification.FLAG_FOREGROUND_SERVICE) != 0
+                || (flags & Notification.FLAG_ONGOING_EVENT) != 0) {
+            return;
+        }
+
+        Bundle extras = notification.extras;
+        if (extras == null) {
+            Log.i(TAG, "notification has no extras, pkg=" + sbn.getPackageName());
+            return;
+        }
+
+        String title = firstText(extras, Notification.EXTRA_TITLE, Notification.EXTRA_TITLE_BIG);
+        String body = collectBody(extras);
+        if (body.isEmpty()) {
+            Log.i(TAG, "notification has no readable body, pkg=" + sbn.getPackageName());
+            return;
+        }
+        // Keep this at INFO because the in-app syslog intentionally filters
+        // out verbose logcat output. The body itself is never written to logs.
+        Log.i(TAG, "notification posted pkg=" + sbn.getPackageName()
+                + ", title=" + title + ", bodyLength=" + body.length());
+        if (isRedacted(body)) {
+            Log.w(TAG, "notification body is redacted, pkg=" + sbn.getPackageName());
+            return;
+        }
+
+        String sender = title.trim().isEmpty() ? sbn.getPackageName() : title.trim();
+        long timestamp = sbn.getPostTime() > 0 ? sbn.getPostTime() : System.currentTimeMillis();
+
+        Log.i(TAG, "Notification received pkg=" + sbn.getPackageName()
+                + ", sender=" + sender + ", bodyLength=" + body.length());
+
+        SmsBroadcastReceiver.forwardNotificationMessage(
+                getApplicationContext(),
+                sender,
+                body,
+                timestamp
+        );
+    }
+
+    @Override
+    public void onNotificationRemoved(StatusBarNotification sbn) {
+        super.onNotificationRemoved(sbn);
+    }
+
+    @Override
+    public void onListenerDisconnected() {
+        super.onListenerDisconnected();
+        Log.w(TAG, "notification listener disconnected");
+        requestRebindIfEnabled(getApplicationContext(), "listener disconnected");
+    }
+
+    /**
+     * Rebinds after an OEM has killed the listener process. The framework only
+     * accepts requestRebind when the user still grants notification access, so
+     * check that secure setting first and make the recovery attempt observable
+     * in the in-app syslog.
+     */
+    static void requestRebindIfEnabled(Context context, String reason) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return;
+        }
+        if (!isNotificationAccessEnabled(context)) {
+            Log.i(TAG, "notification access is not enabled; skip rebind (" + reason + ")");
+            return;
+        }
+
+        try {
+            NotificationListenerService.requestRebind(
+                    new ComponentName(context, NotificationListener.class));
+            Log.i(TAG, "requested notification listener rebind (" + reason + ")");
+        } catch (RuntimeException e) {
+            Log.e(TAG, "failed to request notification listener rebind (" + reason + ")", e);
+        }
+    }
+
+    static boolean isNotificationAccessEnabled(Context context) {
+        String enabled = Settings.Secure.getString(
+                context.getContentResolver(), ENABLED_NOTIFICATION_LISTENERS);
+        if (enabled == null || enabled.isEmpty()) {
+            return false;
+        }
+
+        ComponentName expected = new ComponentName(context, NotificationListener.class);
+        String[] components = enabled.split(":");
+        for (String component : components) {
+            ComponentName enabledComponent = ComponentName.unflattenFromString(component);
+            if (expected.equals(enabledComponent)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static String collectBody(Bundle extras) {
+        Set<String> values = new LinkedHashSet<>();
+        for (String key : BODY_KEYS) {
+            CharSequence value = extras.getCharSequence(key);
+            if (value != null && !value.toString().trim().isEmpty()) {
+                values.add(value.toString().trim());
+            }
+        }
+
+        CharSequence[] lines = extras.getCharSequenceArray(Notification.EXTRA_TEXT_LINES);
+        if (lines != null) {
+            for (CharSequence line : lines) {
+                if (line != null && !line.toString().trim().isEmpty()) {
+                    values.add(line.toString().trim());
+                }
+            }
+        }
+
+        StringBuilder result = new StringBuilder();
+        for (String value : values) {
+            if (result.length() > 0) {
+                result.append('\n');
+            }
+            result.append(value);
+        }
+        return result.toString();
+    }
+
+    private static String firstText(Bundle extras, String... keys) {
+        for (String key : keys) {
+            CharSequence value = extras.getCharSequence(key);
+            if (value != null && !value.toString().trim().isEmpty()) {
+                return value.toString().trim();
+            }
+        }
+        return "";
+    }
+
+    private static boolean isRedacted(String body) {
+        for (String redacted : REDACTED_TEXTS) {
+            if (body.contains(redacted)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/tech/bogomolov/incomingsmsgateway/SmsBroadcastReceiver.java
+++ b/app/src/main/java/tech/bogomolov/incomingsmsgateway/SmsBroadcastReceiver.java
@@ -3,6 +3,7 @@ package tech.bogomolov.incomingsmsgateway;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.telephony.SmsMessage;
 import android.util.Log;
@@ -10,76 +11,197 @@ import android.util.Log;
 import androidx.work.Data;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 public class SmsBroadcastReceiver extends BroadcastReceiver {
+
+    private static final long FORWARD_DEDUPE_WINDOW_MS = 30_000L;
+    private static final int MAX_DEDUPE_ENTRIES = 512;
+    private static final Map<String, RecentForwarding> RECENT_FORWARDINGS = new ConcurrentHashMap<>();
+
+    private static final class RecentForwarding {
+        private final String source;
+        private final long timestamp;
+
+        private RecentForwarding(String source, long timestamp) {
+            this.source = source;
+            this.timestamp = timestamp;
+        }
+    }
 
     private Context context;
 
     @Override
     public void onReceive(Context context, Intent intent) {
         this.context = context;
+        Log.i("SmsBroadcastReceiver", "SMS_RECEIVED broadcast received");
 
         Bundle bundle = intent.getExtras();
         if (bundle == null) {
+            Log.w("SmsBroadcastReceiver", "SMS broadcast has no extras");
             return;
         }
 
         Object[] pdus = (Object[]) bundle.get("pdus");
         if (pdus == null || pdus.length == 0) {
+            Log.w("SmsBroadcastReceiver", "SMS broadcast has no PDUs");
             return;
         }
 
+        String format = bundle.getString("format");
         StringBuilder content = new StringBuilder();
-        final SmsMessage[] messages = new SmsMessage[pdus.length];
+        SmsMessage firstMessage = null;
         for (int i = 0; i < pdus.length; i++) {
-            messages[i] = SmsMessage.createFromPdu((byte[]) pdus[i]);
-            content.append(messages[i].getDisplayMessageBody());
+            SmsMessage message = parseMessage((byte[]) pdus[i], format);
+            if (message == null) {
+                continue;
+            }
+            if (firstMessage == null) {
+                firstMessage = message;
+            }
+            content.append(message.getDisplayMessageBody());
+        }
+
+        if (firstMessage == null) {
+            Log.e("SmsBroadcastReceiver", "Unable to parse any SMS PDU (format=" + format + ")");
+            return;
         }
 
         ArrayList<ForwardingConfig> configs = ForwardingConfig.getAll(context);
         String asterisk = context.getString(R.string.asterisk);
 
-        String sender = messages[0].getOriginatingAddress();
-        if (sender == null) {
-            return;
+        String sender = firstMessage.getOriginatingAddress();
+        if (sender == null || sender.trim().isEmpty()) {
+            // Some devices omit the originating address for short-code or
+            // alphanumeric SMS. Keep wildcard rules usable instead of dropping the SMS.
+            Log.w("SmsBroadcastReceiver", "SMS has no originating address (format=" + format + ")");
+            sender = "Unknown sender";
         }
+
+        // Do not log the SMS body: verification codes are sensitive. These fields
+        // are enough to compare normal and service messages in logcat.
+        Log.i("SmsBroadcastReceiver", "Received SMS format=" + format
+                + ", parts=" + pdus.length
+                + ", sender=" + sender
+                + ", bodyLength=" + content.length()
+                + ", rules=" + configs.size());
+
+        int slotId = this.detectSim(bundle) + 1;
+        String slotName = "undetected";
+        if (slotId < 0) {
+            slotId = 0;
+        }
+        if (slotId > 0) {
+            slotName = "sim" + slotId;
+        }
+
+        forwardMessage(context, sender, content.toString(), slotName, slotId,
+                firstMessage.getTimestampMillis(), "sms", this);
+    }
+
+    /**
+     * Sends a message through all matching rules. Both SMS_RECEIVED and the
+     * notification-listener fallback use this method so sender/filter/HMAC/
+     * retry behaviour cannot drift between the two input paths.
+     *
+     * @param simSlot one-based SIM slot, or 0 when the source has no SIM data
+     * @param source diagnostic source label (for example "sms" or "notification")
+     */
+    static boolean forwardMessage(Context context, String sender, String content,
+                                  String slotName, int simSlot, long timeStamp, String source) {
+        return forwardMessage(context, sender, content, slotName, simSlot, timeStamp,
+                source, null);
+    }
+
+    static boolean forwardNotificationMessage(Context context, String sender, String content,
+                                               long timeStamp) {
+        return forwardMessage(context, sender, content, "notification", 0, timeStamp,
+                "notification", null);
+    }
+
+    private static boolean forwardMessage(Context context, String sender, String content,
+                                          String slotName, int simSlot, long timeStamp,
+                                          String source, SmsBroadcastReceiver receiver) {
+        if (context == null || content == null || content.isEmpty()) {
+            return false;
+        }
+
+        ArrayList<ForwardingConfig> configs = ForwardingConfig.getAll(context);
+        String asterisk = context.getString(R.string.asterisk);
+        boolean forwarded = false;
 
         for (ForwardingConfig config : configs) {
             if (!matchesSender(config, sender, asterisk)) {
                 continue;
             }
-
             if (!config.getIsSmsEnabled()) {
                 continue;
             }
-
-            if (!matchesFilter(config.getSmsFilter(), content.toString())) {
+            if ("notification".equals(source)) {
+                String notificationFilter = config.getNotificationFilter();
+                if (!matchesNotificationFilter(notificationFilter, content)) {
+                    continue;
+                }
+            } else if (!matchesFilter(config.getSmsFilter(), content)) {
+                continue;
+            }
+            // A notification has no reliable SIM identity. Rules pinned to a
+            // specific slot remain SMS-only instead of being sent from an
+            // arbitrary account.
+            if (config.getSimSlot() > 0 && config.getSimSlot() != simSlot) {
                 continue;
             }
 
-            int slotId = this.detectSim(bundle) + 1;
-            String slotName = "undetected";
-            if (slotId < 0) {
-                slotId = 0;
-            }
-
-            if (config.getSimSlot() > 0 && config.getSimSlot() != slotId) {
+            String dedupeKey = buildDedupeKey(config, sender, content);
+            if (isRecentDuplicate(dedupeKey, source)) {
+                Log.i("SmsBroadcastReceiver", "Skipping duplicate " + source
+                        + " notification sender=" + sender);
+                forwarded = true;
                 continue;
             }
 
-            if (slotId > 0) {
-                slotName = "sim" + slotId;
+            if (receiver != null) {
+                // Keep the instance callback for the existing instrumentation
+                // tests and for OEMs that subclass the receiver.
+                receiver.callWebHook(config, sender, slotName, content, timeStamp);
+            } else {
+                enqueueWebhook(context, config, sender, slotName, content, timeStamp);
             }
+            Log.i("SmsBroadcastReceiver", "Enqueued " + source + " webhook sender="
+                    + sender + ", slot=" + slotName);
+            forwarded = true;
+        }
 
-            this.callWebHook(config, sender, slotName, content.toString(), messages[0].getTimestampMillis());
+        if (!forwarded) {
+            Log.w("SmsBroadcastReceiver", "No forwarding rule matched " + source
+                    + " sender=" + sender + ", bodyLength=" + content.length());
+        }
+        return forwarded;
+    }
+
+    private SmsMessage parseMessage(byte[] pdu, String format) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && format != null && !format.isEmpty()) {
+                return SmsMessage.createFromPdu(pdu, format);
+            }
+            return SmsMessage.createFromPdu(pdu);
+        } catch (RuntimeException exception) {
+            Log.e("SmsBroadcastReceiver", "Unable to parse SMS PDU (format=" + format + ")", exception);
+            return null;
         }
     }
 
     protected void callWebHook(ForwardingConfig config, String sender, String slotName,
                                String content, long timeStamp) {
+        enqueueWebhook(this.context, config, sender, slotName, content, timeStamp);
+    }
+
+    private static void enqueueWebhook(Context context, ForwardingConfig config, String sender,
+                                       String slotName, String content, long timeStamp) {
 
         String message = config.prepareMessage(sender, content, slotName, timeStamp);
 
@@ -96,7 +218,37 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
                 .putBoolean(RequestWorker.DATA_LOCAL_MODE, config.getLocalMode())
                 .build();
 
-        RequestWorker.enqueue(this.context, data);
+        RequestWorker.enqueue(context, data);
+    }
+
+    private static String buildDedupeKey(ForwardingConfig config, String sender, String content) {
+        String configKey = config.getKey();
+        if (configKey == null || configKey.isEmpty()) {
+            configKey = config.getSender() + "|" + config.getUrl();
+        }
+        String normalized = content.trim().replaceAll("\\s+", " ");
+        return configKey + "\u0000" + sender + "\u0000" + normalized;
+    }
+
+    private static boolean isRecentDuplicate(String key, String source) {
+        long now = System.currentTimeMillis();
+        RecentForwarding previous = RECENT_FORWARDINGS.get(key);
+        if (previous != null) {
+            if (("notification".equals(source) || !previous.source.equals(source))
+                    && now - previous.timestamp < FORWARD_DEDUPE_WINDOW_MS) {
+                return true;
+            }
+        }
+        RECENT_FORWARDINGS.put(key, new RecentForwarding(source, now));
+
+        if (RECENT_FORWARDINGS.size() > MAX_DEDUPE_ENTRIES) {
+            for (Map.Entry<String, RecentForwarding> entry : RECENT_FORWARDINGS.entrySet()) {
+                if (now - entry.getValue().timestamp >= FORWARD_DEDUPE_WINDOW_MS) {
+                    RECENT_FORWARDINGS.remove(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        return false;
     }
 
     // Per-config sender match. The asterisk wildcard always means "any sender"
@@ -141,6 +293,21 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
         } catch (PatternSyntaxException e) {
             Log.e("SmsBroadcastReceiver", "Invalid filter regex \"" + filter + "\": " + e.getMessage());
             return true;
+        }
+    }
+
+    // Notification filters are opt-in and fail closed: an invalid pattern
+    // must never cause arbitrary notification text to be forwarded.
+    static boolean matchesNotificationFilter(String filter, String content) {
+        if (filter == null || filter.isEmpty()) {
+            return true;
+        }
+        try {
+            return Pattern.compile(filter).matcher(content).find();
+        } catch (PatternSyntaxException e) {
+            Log.e("SmsBroadcastReceiver", "Invalid notification filter regex \""
+                    + filter + "\": " + e.getMessage());
+            return false;
         }
     }
 

--- a/app/src/main/res/layout/dialog_config_edit_form.xml
+++ b/app/src/main/res/layout/dialog_config_edit_form.xml
@@ -73,6 +73,22 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_medium"
+            android:hint="@string/label_notification_filter"
+            app:helperText="@string/notification_filter_recommendation">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_notification_filter"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/AppTheme.TextInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_medium"
             android:hint="@string/label_url"
             app:helperText="@string/input_url">
 

--- a/app/src/main/res/menu/action_bar_menu.xml
+++ b/app/src/main/res/menu/action_bar_menu.xml
@@ -13,6 +13,11 @@
         app:showAsAction="always"
         />
     <item
+        android:id="@+id/action_bar_notification_access"
+        android:title="@string/menu_notification_access"
+        app:showAsAction="never"
+        />
+    <item
         android:id="@+id/action_bar_syslogs"
         android:title="@string/menu_syslog"
         app:showAsAction="never"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -31,6 +31,8 @@
     <string name="hint_sign_hmac_sha256_secret">Секретный ключ HMAC-SHA-256</string>
     <string name="label_sms_filter">Фильтр по тексту (regex, необязательно)</string>
     <string name="sms_filter_recommendation">Пересылать, только если сообщение соответствует этому regex. Напр., OTP пересылает сообщения, содержащие OTP; (?s)^(?!.*OTP) пересылает те, что не содержат.</string>
+    <string name="label_notification_filter">Фильтр текста уведомления (regex, необязательно)</string>
+    <string name="notification_filter_recommendation">Применяется только к резервной пересылке из уведомлений. Оставьте пустым, чтобы пересылать весь читаемый текст уведомлений; непустой regex пересылает только совпадающий текст.</string>
     <string name="sender_recommendation">Используйте символ * для перехвата любого SMS-сообщения</string>
     <string name="label_sender_regex">Отправитель — регулярное выражение</string>
     <string name="sender_regex_info">Сопоставлять отправителя как regex (подстрока). Напр., BANK подходит для VM-BANK и AD-BANK. Символ * выше по-прежнему означает любого отправителя.</string>
@@ -47,6 +49,8 @@
     <string name="notification_channel">По умолчанию</string>
     <string name="menu_syslog">Журнал</string>
     <string name="menu_settings">Настройки</string>
+    <string name="menu_notification_access">Доступ к уведомлениям</string>
+    <string name="notification_access_unavailable">Настройки доступа к уведомлениям недоступны на этом устройстве.</string>
     <string name="title_settings">Настройки</string>
     <string name="label_heartbeat_section">Мониторинг работоспособности</string>
     <string name="heartbeat_info">Периодически отправляет запрос на URL, чтобы внешний сервис мониторинга (например, healthchecks.io, Uptime Kuma, cronitor) мог оповестить вас, если этот телефон перестанет работать и запросы прекратятся.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="sign_hmac_sha256_info">Hex signature will be included to the request headers as \"X-Signature\"</string>
     <string name="label_sms_filter">Text filter (regex, optional)</string>
     <string name="sms_filter_recommendation">Forward only if the message matches this regex. E.g. OTP forwards messages containing OTP; (?s)^(?!.*OTP) forwards those that don\'t.</string>
+    <string name="label_notification_filter">Notification text filter (regex, optional)</string>
+    <string name="notification_filter_recommendation">Applied only to notification fallback. Leave empty to forward all readable notification text; a non-empty regex forwards only matching text.</string>
     <string name="hint_sign_hmac_sha256_secret">HMAC-SHA-256 Secret</string>
     <string name="sender_recommendation">Use * symbol to catch any SMS</string>
     <string name="label_sender_regex">Sender is a regular expression</string>
@@ -47,6 +49,8 @@
     <string name="notification_channel">Default</string>
     <string name="menu_syslog">Syslog</string>
     <string name="menu_settings">Settings</string>
+    <string name="menu_notification_access">Notification access</string>
+    <string name="notification_access_unavailable">Notification access settings are unavailable on this device.</string>
     <string name="title_settings">Settings</string>
     <string name="label_heartbeat_section">Heartbeat monitoring</string>
     <string name="heartbeat_info">Periodically pings a URL so an external monitor (e.g. healthchecks.io, Uptime Kuma, cronitor) can alert you if this phone stops working and the pings stop.</string>

--- a/app/src/test/java/tech/bogomolov/incomingsmsgateway/SmsBroadcastReceiverMatchTest.java
+++ b/app/src/test/java/tech/bogomolov/incomingsmsgateway/SmsBroadcastReceiverMatchTest.java
@@ -91,4 +91,23 @@ public class SmsBroadcastReceiverMatchTest {
         // drops SMS — the opposite of the sender matcher.
         assertTrue(SmsBroadcastReceiver.matchesFilter("[unclosed", "any body"));
     }
+
+    @Test
+    public void notificationFilterMatchesOnlyNotificationContent() {
+        assertTrue(SmsBroadcastReceiver.matchesNotificationFilter(
+                "(?i)呱呱研选.*验证码", "【呱呱研选】您的验证码为：420790"));
+        assertFalse(SmsBroadcastReceiver.matchesNotificationFilter(
+                "(?i)呱呱研选.*验证码", "【呱呱研选】活动提醒"));
+    }
+
+    @Test
+    public void emptyNotificationFilterAllowsAllReadableNotificationText() {
+        assertTrue(SmsBroadcastReceiver.matchesNotificationFilter("", "你好，你中奖了"));
+        assertTrue(SmsBroadcastReceiver.matchesNotificationFilter(null, "普通微信消息"));
+    }
+
+    @Test
+    public void invalidNotificationFilterFailsClosed() {
+        assertFalse(SmsBroadcastReceiver.matchesNotificationFilter("[unclosed", "any body"));
+    }
 }


### PR DESCRIPTION
This adds an optional NotificationListenerService fallback for devices/OEMs that do not reliably deliver some SMS_RECEIVED broadcasts. The listener only works after the user explicitly enables notification access in Android settings. It reuses the existing forwarding pipeline, templates, HMAC signing, retry queue, and sender matching. Notification forwarding has its own optional regex filter and fails closed on invalid notification filters.\n\nTests were added for notification filter matching and config persistence.\n\nLocal note: I could not run Gradle tests on this machine because it currently uses JDK 8, while this project requires JDK 17+.